### PR TITLE
let slippi attempt cleanup on console shutdown

### DIFF
--- a/kernel/SlippiNetwork.h
+++ b/kernel/SlippiNetwork.h
@@ -14,5 +14,7 @@
 s32 SlippiNetworkInit();
 void SlippiNetworkShutdown();
 void SlippiNetworkSetNewFile(const char* path);
+void SlippiPowerHandler(void);
+u64 getRemainingBytes(void);
 
 #endif

--- a/kernel/net.c
+++ b/kernel/net.c
@@ -348,3 +348,15 @@ s32 poll(s32 fd, struct pollsd *sds, s32 nsds, s32 timeout)
 	heap_free(0, psds);
 	return res;
 }
+
+s32 shutdown(s32 fd, s32 socket, u32 how)
+{
+	s32 res;
+	STACK_ALIGN(u32, params, 2, 32);
+
+	params[0] = socket;
+	params[1] = how;
+
+	res = IOS_Ioctl(fd, IOCTL_SO_SHUTDOWN, params, 8, 0, 0);
+	return res;
+}

--- a/kernel/net.h
+++ b/kernel/net.h
@@ -34,6 +34,12 @@ struct pollsd {
 #define POLLHUP				0x0010
 #define POLLNVAL			0x0020
 
+// shutdown arguments
+#define SHUT_RD		0
+#define SHUT_WR		1
+#define SHUT_RDWR	2
+
+
 struct setsockopt_params {
 	u32 socket;
 	u32 level;
@@ -150,5 +156,6 @@ s32 sendto(s32 fd, s32 socket, void *data, s32 len, u32 flags);
 s32 connect(s32 fd, s32 socket, struct address *addr);
 s32 recvfrom(s32 fd, s32 socket, void *mem, s32 len, u32 flags);
 s32 poll(s32 fd, struct pollsd *sds, s32 nsds, s32 timeout);
+s32 shutdown(s32 fd, s32 socket, u32 how);
 
 #endif


### PR DESCRIPTION
If networking is enabled, hook the power button handler:
  - Wait up to 3 seconds for the network thread to finish transmitting
  - Send a single packet with the string "SHUT"
  - Proceed with shutdown