### PR TITLE
Fix Building

### DIFF
--- a/kernel/global.h
+++ b/kernel/global.h
@@ -184,7 +184,7 @@ enum Gameregion
 	REGION_EXPORT,
 };
 
-enum
+enum TRIGames
 {
 	TRI_NONE = 0,
 	TRI_GP1,
@@ -194,7 +194,7 @@ enum
 	TRI_VS4,
 	TRI_YAK,
 	TRI_SB,
-} TRIGames;
+};
 
 typedef struct
 {

--- a/kernel/ipc.h
+++ b/kernel/ipc.h
@@ -78,7 +78,7 @@ struct ipcmessage
 			struct ioctl_vector *argv;	// 18
 		} ioctlv;
 	};
-} __attribute__((packed)) ipcmessage; 
+} __attribute__((packed)); 
 
 #define IOS_OPEN				0x01
 #define IOS_CLOSE				0x02


### PR DESCRIPTION
Fixes "multiple definition of TRIGames" and "multiple definition of ipcmessage" errors when building (at least on Windows).