### PR TITLE
Update mem_map.txt

### DIFF
--- a/mem_map.txt
+++ b/mem_map.txt
@@ -71,6 +71,7 @@ MEM2
 0x932C0000-0x932C0482=conf_pads
 0x932C0490-0x932C0494=IRSensitivity
 0x932C0494-0x932C0498=SensorBarPosition
+0x932C1000-0x932C1022=important_storage_data (USB)
 0x932F0000-0x932F008F=BTPad
 
 Hardware Registers

--- a/mem_map.txt
+++ b/mem_map.txt
@@ -7,9 +7,9 @@ MEM1
 
 MEM2
 0x90000000-0x91000000=aram
-0x91000000-0x92000000=memcard emu - end point depends on memcard size
-0x92000000-0x92E80000=cache - start point depends on memcard size end point depends on Triforce
-0x92B80000-0x92E80000=(In Triforce mode this is reserved for DIMM memory)
+0x91000000-0x92B70000=iso cache (can be reduced to 0xE80000 bytes / 14.5M in vanilla)
+0x92B70000-0x92B80000=unused
+0x92B80000-0x92E80000=slippi replay buffer
 0x92E80000-0x92F00000=temporary di buffer (Also used by Patch code when processing DSP)
 
 0x92F00000-0x93000000=Nintendont kernel


### PR DESCRIPTION
code references:
[iso cache / unused](https://github.com/project-slippi/Nintendont/blob/668c83bb6c7b8109fbce5a22c99b5200bbe925f2/kernel/ISO.c#L398-L426)
[slippi replay buffer](https://github.com/project-slippi/Nintendont/blob/668c83bb6c7b8109fbce5a22c99b5200bbe925f2/kernel/SlippiMemory.c#L15-L16)

note regarding unused section: [these lines](https://github.com/project-slippi/Nintendont/blob/668c83bb6c7b8109fbce5a22c99b5200bbe925f2/kernel/ISO.c#L403-L405) referring to AMBB seem to be outdated. They were added [Jan 1, 2015](https://github.com/project-slippi/Nintendont/commit/c369c4fd07fdff6156880e07d75683983f98c3c7#diff-e137a14e9410a58d59962ba1fcaf516154e4d1c81336f5c4a07826a40c0afc7bR126) while the `0x10000` byte AMBB buffer seems to be allocated via `malloca` since [Jun 20, 2016](https://github.com/project-slippi/Nintendont/commit/1aff60c7d68b2ed261cc9332efcc6a73d22f4254#diff-094c1567cce333cfd07ad6efde2c30d9e51cd8a512ade21c5562935db3593513R73). Additionally there are no references to `0x12B70000`/`0x92B70000` anywhere in code