### PR TITLE
add loader error messages if no usb device is mounted for slippi file write

### DIFF
--- a/loader/source/diskio.c
+++ b/loader/source/diskio.c
@@ -71,6 +71,9 @@ DSTATUS disk_initialize (
 	if (!disk_isInit[pdrv]) {
 		if (!driver[pdrv]->startup())
 			return STA_NOINIT;
+
+		// Device initialized.
+		disk_isInit[pdrv] = true;
 	}
 	if (!driver[pdrv]->isInserted())
 		return STA_NODISK;
@@ -95,9 +98,6 @@ DSTATUS disk_initialize (
 	// NOTE: endOfPartition isn't usable, since this is a
 	// per-disk cache, not per-partition. Use UINT_MAX-1.
 	cache[pdrv] = _FAT_cache_constructor(4, 64, driver[pdrv], UINT_MAX-1, sectorSize[pdrv]);
-
-	// Device initialized.
-	disk_isInit[pdrv] = true;
 	return 0;
 }
 

--- a/loader/source/global.c
+++ b/loader/source/global.c
@@ -598,7 +598,16 @@ const WCHAR *MountDevice(BYTE pdrv)
 			// Could not mount the filesystem.
 			free(devices[pdrv]);
 			devices[pdrv] = NULL;
+
+			if (pdrv == DEV_USB)
+			{
+				usb_attached = 0;
+			}
 		}
+	}
+	else if (pdrv == DEV_USB)
+	{
+		usb_attached = 0;
 	}
 
 	return (devices[pdrv] ? devInitInfo[pdrv].devNameFF : NULL);
@@ -624,6 +633,11 @@ int UnmountDevice(BYTE pdrv)
 		// Free the FatFS object.
 		free(devices[pdrv]);
 		devices[pdrv] = 0;
+
+		if (pdrv == DEV_USB)
+		{
+			usb_attached = 0;
+		}
 	}
 
 	// Shut down the device driver.

--- a/loader/source/menu.c
+++ b/loader/source/menu.c
@@ -828,11 +828,13 @@ static void Menu_GameSelection_Redraw(MenuCtx *ctx)
 
 			if ((ncfg->UseUSB == 0) && (usb_attached != 1)  && (ncfg->Config & (NIN_CFG_SLIPPI_FILE_WRITE)))
 			{
+				int usbStatusY;
 				switch (disk_status(ncfg->UseUSB ? DEV_SD : DEV_USB)) {
 				case STA_NODISK: {
 					PrintFormat(MENU_SIZE, RED, MENU_POS_X, SettingY(11), "[!] NO WRITE DEVICE");
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(12), "Please insert a USB drive");
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "to write Slippi replays.");
+					usbStatusY = 15;
 					break;
 				}
 				case STA_NOINIT: {
@@ -841,6 +843,7 @@ static void Menu_GameSelection_Redraw(MenuCtx *ctx)
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "There may be a non-Slippi");
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(14), "problem in this Wii's");
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(15), "hardware or software.");
+					usbStatusY = 17;
 					break;
 				}
 				default: {
@@ -848,9 +851,13 @@ static void Menu_GameSelection_Redraw(MenuCtx *ctx)
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(12), "Please format USB drive");
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "as FAT32 or exFAT to write");
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(14), "Slippi replays.");
+					usbStatusY = 16;
 					break;
 				}
 				}
+				PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(usbStatusY), "Restart Slippi Nintendont");
+				PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(usbStatusY + 1), "to check again or start");
+				PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(usbStatusY + 2), "game to try anyway.");
 			}
 
 			// Warn the user if they're running low on USB disk space

--- a/loader/source/menu.c
+++ b/loader/source/menu.c
@@ -849,8 +849,8 @@ static void Menu_GameSelection_Redraw(MenuCtx *ctx)
 				default: {
 					PrintFormat(MENU_SIZE, ORANGE, MENU_POS_X, SettingY(11), "[!] WRITE DEVICE FORMAT");
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(12), "Please format USB drive");
-					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "as FAT32 or exFAT to write");
-					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(14), "Slippi replays.");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "as FAT, FAT32, or exFAT to");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(14), "write Slippi replays.");
 					usbStatusY = 16;
 					break;
 				}

--- a/loader/source/menu.c
+++ b/loader/source/menu.c
@@ -43,6 +43,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "../../common/config/MeleeCodes.h"
 #include "ff_utf8.h"
 #include "ShowGameInfo.h"
+#include "diskio.h"
 
 static u8 meleeCodeSelectionIndices[MELEE_CODES_LINE_ITEM_COUNT];
 static u8 devState = DEV_OK;
@@ -825,8 +826,35 @@ static void Menu_GameSelection_Redraw(MenuCtx *ctx)
 			PrintFormat(DEFAULT_SIZE, (ncfg->Config & (NIN_CFG_SLIPPI_REPLAYS)) ? GREEN : RED, MENU_POS_X+320+(24*10),
 					gamelist_y, "%-3s", (ncfg->Config & (NIN_CFG_SLIPPI_REPLAYS)) ? "ON" : "OFF");
 
+			if ((ncfg->UseUSB == 0) && (usb_attached != 1)  && (ncfg->Config & (NIN_CFG_SLIPPI_FILE_WRITE)))
+			{
+				switch (disk_status(ncfg->UseUSB ? DEV_SD : DEV_USB)) {
+				case STA_NODISK: {
+					PrintFormat(MENU_SIZE, RED, MENU_POS_X, SettingY(11), "[!] NO WRITE DEVICE");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(12), "Please insert a USB drive");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "to write Slippi replays.");
+					break;
+				}
+				case STA_NOINIT: {
+					PrintFormat(MENU_SIZE, RED, MENU_POS_X, SettingY(11), "[!] INTERNAL ERROR");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(12), "Unable to check USB drive");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "There may be a non-Slippi");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(14), "problem in this Wii's");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(15), "hardware or software.");
+					break;
+				}
+				default: {
+					PrintFormat(MENU_SIZE, ORANGE, MENU_POS_X, SettingY(11), "[!] WRITE DEVICE FORMAT");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(12), "Please format USB drive");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "as FAT32 or exFAT to write");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(14), "Slippi replays.");
+					break;
+				}
+				}
+			}
+
 			// Warn the user if they're running low on USB disk space
-			if ((usb_attached == 1) && (ncfg->Config & (NIN_CFG_SLIPPI_REPLAYS)))
+			if ((ncfg->UseUSB == 0) && (usb_attached == 1) && (ncfg->Config & (NIN_CFG_SLIPPI_REPLAYS)))
 			{
 				int lowUsbWarnThreshold = 500;
 				int lowUsbErrorThreshold = 50;

--- a/loader/source/menu.c
+++ b/loader/source/menu.c
@@ -826,7 +826,7 @@ static void Menu_GameSelection_Redraw(MenuCtx *ctx)
 			PrintFormat(DEFAULT_SIZE, (ncfg->Config & (NIN_CFG_SLIPPI_REPLAYS)) ? GREEN : RED, MENU_POS_X+320+(24*10),
 					gamelist_y, "%-3s", (ncfg->Config & (NIN_CFG_SLIPPI_REPLAYS)) ? "ON" : "OFF");
 
-			if ((ncfg->UseUSB == 0) && (usb_attached != 1)  && (ncfg->Config & (NIN_CFG_SLIPPI_FILE_WRITE)))
+			if ((ncfg->UseUSB == 0) && (usb_attached != 1)  && (ncfg->Config & (NIN_CFG_SLIPPI_REPLAYS)))
 			{
 				int usbStatusY;
 				switch (disk_status(ncfg->UseUSB ? DEV_SD : DEV_USB)) {

--- a/loader/source/menu.c
+++ b/loader/source/menu.c
@@ -849,8 +849,9 @@ static void Menu_GameSelection_Redraw(MenuCtx *ctx)
 				default: {
 					PrintFormat(MENU_SIZE, ORANGE, MENU_POS_X, SettingY(11), "[!] WRITE DEVICE FORMAT");
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(12), "Please format USB drive");
-					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "as FAT, FAT32, or exFAT to");
-					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(14), "write Slippi replays.");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "as FAT32 or exFAT (exFAT");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(14), "recommended) to write");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(15), "Slippi replays.");
 					usbStatusY = 16;
 					break;
 				}

--- a/loader/source/menu.c
+++ b/loader/source/menu.c
@@ -1862,6 +1862,7 @@ bool Menu_DeviceSelection(void)
 				// Therefore attempt to Mount USB when returning to device
 				// selection to keep error messages up to date.
 				ShowMessageScreen("Checking storage devices...");
+				UnmountDevice(DEV_USB);
 				MountDevice(DEV_USB);
 			}
 			else

--- a/loader/source/menu.c
+++ b/loader/source/menu.c
@@ -855,9 +855,7 @@ static void Menu_GameSelection_Redraw(MenuCtx *ctx)
 					break;
 				}
 				}
-				PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(usbStatusY), "Restart Slippi Nintendont");
-				PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(usbStatusY + 1), "to check again or start");
-				PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(usbStatusY + 2), "game to try anyway.");
+				PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(usbStatusY), "Press start to check again");
 			}
 
 			// Warn the user if they're running low on USB disk space
@@ -865,18 +863,25 @@ static void Menu_GameSelection_Redraw(MenuCtx *ctx)
 			{
 				int lowUsbWarnThreshold = 500;
 				int lowUsbErrorThreshold = 50;
-
-				if ((usb_replays_left < lowUsbWarnThreshold) && (usb_replays_left > lowUsbErrorThreshold))
-					PrintFormat(MENU_SIZE, ORANGE, MENU_POS_X, SettingY(11),"[!] WARNING, LOW USB SPACE");
-				if (usb_replays_left <= lowUsbErrorThreshold)
-					PrintFormat(MENU_SIZE, RED, MENU_POS_X, SettingY(11),"[!] WARNING, LOW USB SPACE");
-
-				if (usb_replays_left < lowUsbWarnThreshold) {
+				// Warn the user if they're running low on USB disk space
+				if (usb_replays_left < lowUsbWarnThreshold)
+				{
+					if (usb_replays_left <= lowUsbErrorThreshold)
+						PrintFormat(MENU_SIZE, RED, MENU_POS_X, SettingY(11),"[!] WARNING, LOW USB SPACE");
+					else
+						PrintFormat(MENU_SIZE, ORANGE, MENU_POS_X, SettingY(11),"[!] WARNING, LOW USB SPACE");
+					
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(12), "Your USB drive is running");
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "low on free space. There ");
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(14), "should be enough space for");
 					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(15), "about %d more replays.", 
 							(int)usb_replays_left);
+				}
+				else
+				{
+					PrintFormat(MENU_SIZE, GREEN, MENU_POS_X, SettingY(11), "READY");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(12), "USB drive ready to write");
+					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "Slippi replays.");
 				}
 			}
 		}
@@ -1848,8 +1853,21 @@ bool Menu_DeviceSelection(void)
 		if (FPAD_OK(0))
 		{
 			int ret = Menu_GameSelection();
-			if (ret & 2) res = true;
-			if (ret & 1) break;
+			if (ret == 0)
+			{
+				// We provide error messages when USB file write is set but no
+				// USB drive is ready and advise the user to return to device
+				// selection to check again.
+				// Therefore attempt to Mount USB when returning to device
+				// selection to keep error messages up to date.
+				ShowMessageScreen("Checking storage devices...");
+				MountDevice(DEV_USB);
+			}
+			else
+			{
+				if (ret & 2) res = true;
+				if (ret & 1) break;
+			}
 			redraw = true;
 		}
 		// Return to the loader


### PR DESCRIPTION
currently, Slippi Nintendont shuts down the Wii completely if there is no usable file write device. there is no way to know beforehand if the file write device is usable. these messages will help users verify that their usb drive is usable for file write, and diagnose why if not

this change also fixes a small bug in `diskio.c` regarding init status