### PR TITLE
Prevent black screen boot failure

### DIFF
--- a/kernel/Patch.c
+++ b/kernel/Patch.c
@@ -536,6 +536,7 @@ static void Patch31A0( void )
 		u32 CurBuf = read32(0x319C);
 		//create jump for it
 		PatchB(PatchOffset, 0x319C);
+		sync_after_write((void *)0x319C, 4);
 		if ((CurBuf & 0xFC000002) == 0x40000000)
 		{
 			u32 Orig = CurBuf;


### PR DESCRIPTION
Nintendont patches the executable to preserve the instruction at `0x800031A0` which apparently is used by IOS. However it seems like `sync_after_write` was omitted after the patched branch at `0x8000319C`. I believe this sets up a race where PPC execution may reach `0x0000319C`/`0x000031A0` after IOS overwrites `0x800031A0` but before Nintendont's patch is flushed from ARM cache to memory. This would cause PPC to execute the overwritten data at `0x800031A0` and almost certainly derail execution.

`0x0000319C`/`0x000031A0` is within `__fill_mem 0x80003130`
which is first reached by call stack:

`memset 0x80003100` (`0x80003114`)  
`__init_data 0x8000535c` (`0x800053f4`)  
`__start 0x8000522c` (`0x80005244`)

which fits my experimentally derived lower and upper bounds for where the execution gets stuck (within `__init_data 0x800053c8 - 0x80005400`)

adding `sync_after_write` after the patched branch at `0x8000319C` increases successful boot rate from 2/10 to 10/10 in my worst-case testing (SD card 95% full, ISO at the end of the partition and fragmented, Slippi NET on, logging on, OSReport on).