### PR TITLE
remove free space logic/warning

### DIFF
--- a/fatfs/ffconf.h
+++ b/fatfs/ffconf.h
@@ -198,7 +198,7 @@
 /  disk_ioctl() function. */
 
 
-#define _FS_NOFSINFO	1
+#define _FS_NOFSINFO	0
 /* If you need to know correct free space on the FAT32 volume, set bit 0 of this
 /  option, and f_getfree() function at first time after volume mount will force
 /  a full FAT scan. Bit 1 controls the use of last allocated cluster number.

--- a/loader/source/global.c
+++ b/loader/source/global.c
@@ -516,13 +516,6 @@ int CreateNewFile(const char *Path, unsigned int size)
 FATFS *devices[2];
 
 FATFS *usb_info;
-u32 usb_free_clusters;
-u32 usb_total_sectors;
-u32 usb_free_sectors;
-u32 usb_free_kib;
-u32 usb_total_kib;
-u32 usb_replays_left;
-u32 usb_attached;
 
 // Device initialization data.
 typedef struct _devInitInfo_t
@@ -577,21 +570,6 @@ const WCHAR *MountDevice(BYTE pdrv)
 		if (f_mount(devices[pdrv], devInitInfo[pdrv].devNameFF, 1) == FR_OK)
 		{
 			gprintf("Mounted %s!\n", devInitInfo[pdrv].devNameDisplay);
-
-
-			/* When we mount a USB drive, get the total/free FAT32 space in KiB.
-			 * Calculate the approximate number of replays we could store, assuming
-			 * a replay is somewhere around 1.5MB (1464KiB) */
-			if (pdrv == DEV_USB) 
-			{
-				f_getfree(devInitInfo[pdrv].devNameFF, &usb_free_clusters, &usb_info);
-				usb_total_sectors = (usb_info->n_fatent - 2) * usb_info->csize;
-				usb_free_sectors = usb_free_clusters * usb_info->csize;
-				usb_total_kib = usb_total_sectors / 2;
-				usb_free_kib = usb_free_sectors / 2; 
-				usb_replays_left = usb_free_kib / 1464;
-				usb_attached = 1;
-			}
 		}
 		else
 		{

--- a/loader/source/menu.c
+++ b/loader/source/menu.c
@@ -770,8 +770,6 @@ static bool Menu_GameSelection_InputHandler(MenuCtx *ctx)
 /* Menu_GameSelection_Redraw()
  * Redraw the game selection menu.
  */
-extern u32 usb_replays_left;
-extern u32 usb_attached;
 static void Menu_GameSelection_Redraw(MenuCtx *ctx)
 {
 	u32 i;
@@ -824,26 +822,6 @@ static void Menu_GameSelection_Redraw(MenuCtx *ctx)
 			PrintFormat(DEFAULT_SIZE, BLACK, MENU_POS_X+320+(17*10), gamelist_y, "REPLAY: ");
 			PrintFormat(DEFAULT_SIZE, (ncfg->Config & (NIN_CFG_SLIPPI_REPLAYS)) ? GREEN : RED, MENU_POS_X+320+(24*10),
 					gamelist_y, "%-3s", (ncfg->Config & (NIN_CFG_SLIPPI_REPLAYS)) ? "ON" : "OFF");
-
-			// Warn the user if they're running low on USB disk space
-			if ((usb_attached == 1) && (ncfg->Config & (NIN_CFG_SLIPPI_REPLAYS)))
-			{
-				int lowUsbWarnThreshold = 500;
-				int lowUsbErrorThreshold = 50;
-
-				if ((usb_replays_left < lowUsbWarnThreshold) && (usb_replays_left > lowUsbErrorThreshold))
-					PrintFormat(MENU_SIZE, ORANGE, MENU_POS_X, SettingY(11),"[!] WARNING, LOW USB SPACE");
-				if (usb_replays_left <= lowUsbErrorThreshold)
-					PrintFormat(MENU_SIZE, RED, MENU_POS_X, SettingY(11),"[!] WARNING, LOW USB SPACE");
-
-				if (usb_replays_left < lowUsbWarnThreshold) {
-					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(12), "Your USB drive is running");
-					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(13), "low on free space. There ");
-					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(14), "should be enough space for");
-					PrintFormat(MENU_SIZE, BLACK, MENU_POS_X, SettingY(15), "about %d more replays.", 
-							(int)usb_replays_left);
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
this causes users to get stuck on "Checking Storage Devices..." for longer than necessary if they have a USB storage device plugged in. In the case of FAT32 for sure, the time scales with the total size of the drive. At least one user reported having to wait over 20 seconds.

as well the warning is not terribly useful as it
- only applies to USB storage devices
- shows (extremely) estimated number of replays remaining, instead of something like MiB or player-minutes (since replay size is dependent on number of players)

and is decreasingly useful as more users will be booting without USB storage plugged in due to hotswap

fixes project-slippi/Nintendont#52