### PR TITLE
fix: use defined typedefs in defining app_entry

### DIFF
--- a/multidol/apploader.c
+++ b/multidol/apploader.c
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 typedef int   (*app_main)(char **dst, u32 *size, u32 *offset);
 typedef void  (*app_init)(int (*report)(const char *fmt, ...));
 typedef void *(*app_final)();
-typedef void  (*app_entry)(void (**init)(int (*report)(const char *fmt, ...)), int (**main)(), void *(**final)());
+typedef void  (*app_entry)(app_init*, app_main*, app_final*);
 
 static u8 *appldr = (u8*)0x81200000;
 static struct _TGCInfo *TGCInfo = (struct _TGCInfo*)0x930031E0;


### PR DESCRIPTION
Addresses this issue with types not being correct:

```bash
rei wolf@DESKTOP-8JOF1RA MSYS /c/dev/Nintendont
$ ./'Incremental Build.bat'

C:\dev\Nintendont>make all windows=1

Building Multi-DOL loader

make -C multidol
make[1]: Entering directory '/c/dev/Nintendont/multidol'
 ASSEMBLE    crt0.S
 COMPILE     cache.c
 COMPILE     main.c
 COMPILE     global.c
 COMPILE     apploader.c
apploader.c: In function 'Apploader_Run':
apploader.c:118:36: error: passing argument 2 of 'appldr_entry' from incompatible pointer type [-Wincompatible-pointer-types]
  118 |         appldr_entry(&appldr_init, &appldr_main, &appldr_final);
      |                                    ^~~~~~~~~~~~
      |                                    |
      |                                    int (**)(char **, u32 *, u32 *) {aka int (**)(char **, unsigned int *, unsigned int *)}
apploader.c:118:36: note: expected 'int (**)(void)' but argument is of type 'int (**)(char **, u32 *, u32 *)' {aka 'int (**)(char **, unsigned int *, unsigned int *)'}
make[1]: *** [Makefile:40: apploader.o] Error 1
make[1]: Leaving directory '/c/dev/Nintendont/multidol'
make: *** [Makefile:34: multidol] Error 2
```

If I'm missing anything feel free to comment.