### PR TITLE
feat: add support for a gcc to transmit extra data to nintendont

### DIFF
--- a/kernel/Patch.c
+++ b/kernel/Patch.c
@@ -3424,6 +3424,31 @@ void DoPatches( char *Buffer, u32 Length, u32 DiscOffset )
 		memcpy((void*)gct_cursor, GCT_FOOTER, sizeof(GCT_FOOTER));
 		sync_after_write((void*)gct_cursor, sizeof(GCT_FOOTER));
 		gct_cursor += sizeof(GCT_FOOTER);
+
+		// Hook for controller metadata transfer (native SI mode only)
+		dbgprintf("Patch:ControllerMetadata pre-check: DisableSIPatch=%d MeleeVer=%d\r\n",
+			DisableSIPatch, MeleeVersion);
+		if (DisableSIPatch && MeleeVersion == MELEE_VERSION_NTSC_2)
+		{
+			// PADOriginCallback hook — fires CMD 0x40 right after UpdateOrigin
+			// returns and before SIEnablePolling restarts auto-poll.
+			// The instruction at 0x0034CF4C is: lwz r31, -0x5A68(r13)
+			// This loads ResettingChan after a successful origin read.
+			// Bus is completely idle here — perfect for running a custom SI
+			// command.
+			u32 padOriginPost = 0x0034CF4C;
+			if (read32(padOriginPost) == 0x83EDA598)
+			{
+				u32 hookAddr = PatchCopy(SIGetTypeControllerMetadata, SIGetTypeControllerMetadata_size);
+				PatchBL(hookAddr, padOriginPost);
+				dbgprintf("Patch:[ControllerMetadata] applied in PADOriginCallback (0x%08X)\r\n", padOriginPost);
+			}
+			else
+			{
+				dbgprintf("Patch:[ControllerMetadata] pattern NOT found at 0x%08X (got 0x%08X)\r\n",
+					padOriginPost, read32(padOriginPost));
+			}
+		}
 	}
 
 

--- a/kernel/PatchCodes.h
+++ b/kernel/PatchCodes.h
@@ -28,6 +28,7 @@
 #include "asm/TCIntrruptHandler.h"
 #include "asm/SIIntrruptHandler.h"
 #include "asm/SIInitStore.h"
+#include "asm/SIGetTypeControllerMetadata.h"
 #include "asm/PADRead.h"
 #include "asm/PADControlAllMotors.h"
 #include "asm/PADControlMotor.h"

--- a/kernel/SI.c
+++ b/kernel/SI.c
@@ -24,6 +24,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define SI_GC_CONTROLLER 0x09000000
 #define SI_ERROR_NO_RESPONSE 0x08
 
+/* Shared memory for PPC→ARM extra data (ARM physical address) */
+/* PPC writes to 0xD3080000 (uncached) = ARM 0x13080000.
+ * Per-channel data starts at +0x20 with stride 0x410. */
+#define CONTROLLER_METADATA_BASE 0x13080000
+// 0x20 header + 4 channels * 0x410 stride
+#define CONTROLLER_METADATA_SIZE 0x0AE0
+
+
 u32 SI_IRQ = 0;
 static bool complete = true;
 static u32 cur_control = 0;
@@ -35,6 +43,10 @@ void SIInit()
 	sync_before_read((void*)PAD_BUFF, 0x40);
 	memset((void*)PAD_BUFF, 0, 0x30); //For Triforce to not instantly reset
 	sync_after_write((void*)PAD_BUFF, 0x40);
+
+	// Clear shared memory for PPC to ARM controller metadata
+	memset((void*)CONTROLLER_METADATA_BASE, 0, CONTROLLER_METADATA_SIZE);
+	sync_after_write((void*)CONTROLLER_METADATA_BASE, CONTROLLER_METADATA_SIZE);
 
 	SI_IRQ = 0;
 	complete = true;

--- a/kernel/SI.c
+++ b/kernel/SI.c
@@ -23,18 +23,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #define SI_GC_CONTROLLER 0x09000000
 #define SI_ERROR_NO_RESPONSE 0x08
-#define SI_EXTRA_REQUEST  0x13003500  // ARM-side mirror of 0x93003500
-
-#define SI_HW_BASE       0x0D006400
-#define SI_HW_CONTROL    (SI_HW_BASE + 0x34)
-#define SI_HW_STATUS     (SI_HW_BASE + 0x38)
-#define SI_HW_IO_BUF    (SI_HW_BASE + 0x80)
-
-#define EXTRA_DATA_ADDR  0x13003520
-#define EXTRA_DATA_MAX   1024
-
-#define SI_CMD_EXTRA_DATA   0xF0
-#define SI_CMD_EXTRA_CHUNK  0xF1
 
 u32 SI_IRQ = 0;
 static bool complete = true;
@@ -91,111 +79,8 @@ void SIInterrupt()
 	complete ^= 1;
 }
 
-// One-shot SI transfer using the IO buffer (doesn't touch channel regs)
-static s32 SIRawTransfer(u32 chan, u32 cmdWord, u32 cmdLen, u32 respLen)
-{
-    // Write command into IO buffer
-    write32(SI_HW_IO_BUF, cmdWord);
-
-    // Build control word:
-    // bit 0: start transfer
-    // bits 1-2: channel
-    // bits 8-14: output length (bytes to send)
-    // bits 16-22: input length (bytes to receive)
-    u32 control = (1 << 0)
-                | ((chan & 3) << 1)
-                | ((cmdLen & 0x7F) << 8)
-                | ((respLen & 0x7F) << 16);
-
-    write32(SI_HW_CONTROL, control);
-
-    // Wait for transfer complete
-    u32 timeout = 50000;
-    while (timeout--)
-    {
-        u32 ctrl = read32(SI_HW_CONTROL);
-        if (ctrl & (1 << 31))  // TC bit
-        {
-            // Clear TC
-            write32(SI_HW_CONTROL, ctrl & ~1);
-            if (ctrl & (1 << 29))  // NOREP — no response
-                return -1;
-            return 0;
-        }
-        udelay(1);
-    }
-    return -2;
-}
-
-static void SIReadExtraData(u32 chan)
-{
-    u8 *dest = (u8*)EXTRA_DATA_ADDR + (chan * EXTRA_DATA_MAX);
-
-    // Step 1: Ask RP2040 how much data it has
-    s32 ret = SIRawTransfer(chan, (SI_CMD_EXTRA_DATA << 24), 1, 4);
-    if (ret < 0) return;
-
-    u32 response = read32(SI_HW_IO_BUF);
-    u32 totalSize = response & 0xFFFF;
-    if (totalSize == 0 || totalSize > EXTRA_DATA_MAX) return;
-
-    dbgprintf("SI:Chan%u: Reading %u bytes extra data\r\n", chan, totalSize);
-
-    // Step 2: Read in 60-byte chunks (leave room for cmd overhead)
-    u32 totalRead = 0;
-    u32 chunkIdx = 0;
-    while (totalRead < totalSize)
-    {
-        u32 thisChunk = totalSize - totalRead;
-        if (thisChunk > 60) thisChunk = 60;
-
-        u32 cmd = (SI_CMD_EXTRA_CHUNK << 24) | (chunkIdx << 16);
-        ret = SIRawTransfer(chan, cmd, 3, thisChunk);
-        if (ret < 0)
-        {
-            dbgprintf("SI:Chan%u: Chunk %u failed\r\n", chan, chunkIdx);
-            break;
-        }
-
-        // Copy from IO buffer
-        u32 i;
-        for (i = 0; i < thisChunk; i += 4)
-        {
-            u32 word = read32(SI_HW_IO_BUF + i);
-            dest[totalRead + i + 0] = (word >> 24) & 0xFF;
-            dest[totalRead + i + 1] = (word >> 16) & 0xFF;
-            dest[totalRead + i + 2] = (word >>  8) & 0xFF;
-            dest[totalRead + i + 3] = (word >>  0) & 0xFF;
-        }
-
-        totalRead += thisChunk;
-        chunkIdx++;
-    }
-
-    dest[totalRead] = 0;
-    sync_after_write(dest, (EXTRA_DATA_MAX + 31) & ~31);
-    dbgprintf("SI:Chan%u: Extra data: \"%s\"\r\n", chan, dest);
-}
-
 void SIUpdateRegisters()
 {
-    // === Check if PPC signaled a new controller ===
-    sync_before_read((void*)SI_EXTRA_REQUEST, 0x20);
-    u32 chan;
-    for (chan = 0; chan < 4; chan++)
-    {
-        u32 request = read32(SI_EXTRA_REQUEST + (chan * 4));
-        if (request == 1)
-        {
-            // PPC detected a new controller — read extra data now
-            SIReadExtraData(chan);
-
-            // Signal back to PPC that we're done
-            write32(SI_EXTRA_REQUEST + (chan * 4), 2);
-            sync_after_write((void*)SI_EXTRA_REQUEST, 0x20);
-        }
-    }
-
 	sync_before_read((void*)SI_BASE, 0x100);
 	cur_control = read32(SI_CONTROL);
 	u32 cur_status = read32(SI_STATUS);

--- a/kernel/SI.c
+++ b/kernel/SI.c
@@ -23,6 +23,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #define SI_GC_CONTROLLER 0x09000000
 #define SI_ERROR_NO_RESPONSE 0x08
+#define SI_EXTRA_REQUEST  0x13003500  // ARM-side mirror of 0x93003500
+
+#define SI_HW_BASE       0x0D006400
+#define SI_HW_CONTROL    (SI_HW_BASE + 0x34)
+#define SI_HW_STATUS     (SI_HW_BASE + 0x38)
+#define SI_HW_IO_BUF    (SI_HW_BASE + 0x80)
+
+#define EXTRA_DATA_ADDR  0x13003520
+#define EXTRA_DATA_MAX   1024
+
+#define SI_CMD_EXTRA_DATA   0xF0
+#define SI_CMD_EXTRA_CHUNK  0xF1
 
 u32 SI_IRQ = 0;
 static bool complete = true;
@@ -79,8 +91,111 @@ void SIInterrupt()
 	complete ^= 1;
 }
 
+// One-shot SI transfer using the IO buffer (doesn't touch channel regs)
+static s32 SIRawTransfer(u32 chan, u32 cmdWord, u32 cmdLen, u32 respLen)
+{
+    // Write command into IO buffer
+    write32(SI_HW_IO_BUF, cmdWord);
+
+    // Build control word:
+    // bit 0: start transfer
+    // bits 1-2: channel
+    // bits 8-14: output length (bytes to send)
+    // bits 16-22: input length (bytes to receive)
+    u32 control = (1 << 0)
+                | ((chan & 3) << 1)
+                | ((cmdLen & 0x7F) << 8)
+                | ((respLen & 0x7F) << 16);
+
+    write32(SI_HW_CONTROL, control);
+
+    // Wait for transfer complete
+    u32 timeout = 50000;
+    while (timeout--)
+    {
+        u32 ctrl = read32(SI_HW_CONTROL);
+        if (ctrl & (1 << 31))  // TC bit
+        {
+            // Clear TC
+            write32(SI_HW_CONTROL, ctrl & ~1);
+            if (ctrl & (1 << 29))  // NOREP — no response
+                return -1;
+            return 0;
+        }
+        udelay(1);
+    }
+    return -2;
+}
+
+static void SIReadExtraData(u32 chan)
+{
+    u8 *dest = (u8*)EXTRA_DATA_ADDR + (chan * EXTRA_DATA_MAX);
+
+    // Step 1: Ask RP2040 how much data it has
+    s32 ret = SIRawTransfer(chan, (SI_CMD_EXTRA_DATA << 24), 1, 4);
+    if (ret < 0) return;
+
+    u32 response = read32(SI_HW_IO_BUF);
+    u32 totalSize = response & 0xFFFF;
+    if (totalSize == 0 || totalSize > EXTRA_DATA_MAX) return;
+
+    dbgprintf("SI:Chan%u: Reading %u bytes extra data\r\n", chan, totalSize);
+
+    // Step 2: Read in 60-byte chunks (leave room for cmd overhead)
+    u32 totalRead = 0;
+    u32 chunkIdx = 0;
+    while (totalRead < totalSize)
+    {
+        u32 thisChunk = totalSize - totalRead;
+        if (thisChunk > 60) thisChunk = 60;
+
+        u32 cmd = (SI_CMD_EXTRA_CHUNK << 24) | (chunkIdx << 16);
+        ret = SIRawTransfer(chan, cmd, 3, thisChunk);
+        if (ret < 0)
+        {
+            dbgprintf("SI:Chan%u: Chunk %u failed\r\n", chan, chunkIdx);
+            break;
+        }
+
+        // Copy from IO buffer
+        u32 i;
+        for (i = 0; i < thisChunk; i += 4)
+        {
+            u32 word = read32(SI_HW_IO_BUF + i);
+            dest[totalRead + i + 0] = (word >> 24) & 0xFF;
+            dest[totalRead + i + 1] = (word >> 16) & 0xFF;
+            dest[totalRead + i + 2] = (word >>  8) & 0xFF;
+            dest[totalRead + i + 3] = (word >>  0) & 0xFF;
+        }
+
+        totalRead += thisChunk;
+        chunkIdx++;
+    }
+
+    dest[totalRead] = 0;
+    sync_after_write(dest, (EXTRA_DATA_MAX + 31) & ~31);
+    dbgprintf("SI:Chan%u: Extra data: \"%s\"\r\n", chan, dest);
+}
+
 void SIUpdateRegisters()
 {
+    // === Check if PPC signaled a new controller ===
+    sync_before_read((void*)SI_EXTRA_REQUEST, 0x20);
+    u32 chan;
+    for (chan = 0; chan < 4; chan++)
+    {
+        u32 request = read32(SI_EXTRA_REQUEST + (chan * 4));
+        if (request == 1)
+        {
+            // PPC detected a new controller — read extra data now
+            SIReadExtraData(chan);
+
+            // Signal back to PPC that we're done
+            write32(SI_EXTRA_REQUEST + (chan * 4), 2);
+            sync_after_write((void*)SI_EXTRA_REQUEST, 0x20);
+        }
+    }
+
 	sync_before_read((void*)SI_BASE, 0x100);
 	cur_control = read32(SI_CONTROL);
 	u32 cur_status = read32(SI_STATUS);

--- a/kernel/SlippiFileWriter.c
+++ b/kernel/SlippiFileWriter.c
@@ -134,9 +134,10 @@ void writeHeader(FIL *file)
 }
 
 /* Validate that buf[0..len) is a UBJSON object containing only string
- * values with int8/uint8-length keys and values, all printable ASCII.
- * Accepts both 'U' (uint8) and 'i' (int8) as length type markers.
- * Returns the validated byte count (including { and }), or 0 on failure. */
+ * values with uint8-length keys and values, all printable ASCII.
+ * Required format per field: key is "U <len> <bytes>", value is
+ * "S U <len> <bytes>". Returns validated byte count including { and }.
+ */
 static u16 validateUbjsonStringDict(const u8 *buf, u16 len)
 {
 	if (len < 2 || buf[0] != '{')
@@ -146,8 +147,8 @@ static u16 validateUbjsonStringDict(const u8 *buf, u16 len)
 	while (pos < len && buf[pos] != '}')
 	{
 		u16 i;
-		/* Key: U/i <keyLen> <keyBytes> */
-		if (pos + 2 > len || (buf[pos] != 'U' && buf[pos] != 'i'))
+		/* Key: U <keyLen> <keyBytes> */
+		if (pos + 2 > len || buf[pos] != 'U')
 			return 0;
 		u8 keyLen = buf[pos + 1];
 		pos += 2;
@@ -158,9 +159,8 @@ static u16 validateUbjsonStringDict(const u8 *buf, u16 len)
 				return 0;
 		pos += keyLen;
 
-		/* Value: S U/i <valLen> <valBytes> */
-		if (pos + 3 > len || buf[pos] != 'S' ||
-		    (buf[pos + 1] != 'U' && buf[pos + 1] != 'i'))
+		/* Value: S U <valLen> <valBytes> */
+		if (pos + 3 > len || buf[pos] != 'S' || buf[pos + 1] != 'U')
 			return 0;
 		u8 valLen = buf[pos + 2];
 		pos += 3;

--- a/kernel/SlippiFileWriter.c
+++ b/kernel/SlippiFileWriter.c
@@ -17,7 +17,16 @@
 #define THREAD_ERROR_TIME_MS 2000
 #define LED_FLASH_TIME_MS 1000
 
-#define FOOTER_BUFFER_LENGTH 200
+#define FOOTER_BUFFER_LENGTH 2048
+
+// Shared memory for CMD 0xA0xx controller metadata (ARM physical)
+#define SFW_EXTRA_DATA_ADDR  0x13080020
+#define SFW_XDATA_STRIDE     0x0410
+#define SFW_XOFF_NCHUNKS     0x08
+#define SFW_XOFF_CHUNKS      0x10
+#define SFW_CHUNK_SIZE       128
+// INLNGTH=80 minus 2-byte header per chunk
+#define SFW_CHUNK_DATA        78
 
 static u32 SlippiHandlerThread(void *arg);
 
@@ -124,9 +133,79 @@ void writeHeader(FIL *file)
 	f_sync(file);
 }
 
+/* Validate that buf[0..len) is a UBJSON object containing only string
+ * values with int8/uint8-length keys and values, all printable ASCII.
+ * Accepts both 'U' (uint8) and 'i' (int8) as length type markers.
+ * Returns the validated byte count (including { and }), or 0 on failure. */
+static u16 validateUbjsonStringDict(const u8 *buf, u16 len)
+{
+	if (len < 2 || buf[0] != '{')
+		return 0;
+
+	u16 pos = 1;
+	while (pos < len && buf[pos] != '}')
+	{
+		u16 i;
+		/* Key: U/i <keyLen> <keyBytes> */
+		if (pos + 2 > len || (buf[pos] != 'U' && buf[pos] != 'i'))
+			return 0;
+		u8 keyLen = buf[pos + 1];
+		pos += 2;
+		if (keyLen == 0 || pos + keyLen > len)
+			return 0;
+		for (i = 0; i < keyLen; i++)
+			if (buf[pos + i] < 0x20 || buf[pos + i] > 0x7E)
+				return 0;
+		pos += keyLen;
+
+		/* Value: S U/i <valLen> <valBytes> */
+		if (pos + 3 > len || buf[pos] != 'S' ||
+		    (buf[pos + 1] != 'U' && buf[pos + 1] != 'i'))
+			return 0;
+		u8 valLen = buf[pos + 2];
+		pos += 3;
+		if (pos + valLen > len)
+			return 0;
+		for (i = 0; i < valLen; i++)
+			if (buf[pos + i] < 0x20 || buf[pos + i] > 0x7E)
+				return 0;
+		pos += valLen;
+	}
+
+	if (pos >= len || buf[pos] != '}')
+		return 0;
+
+	return pos + 1;
+}
+
+/* Reassemble data from raw 80-byte SI chunks into a contiguous buffer.
+ * Every chunk has a 2-byte header (total, current); data is bytes 2..79.
+ * Returns number of bytes written to dest. */
+static u16 reassembleControllerMetadata(u32 chanBase, u8 *dest, u16 maxLen)
+{
+	u32 nChunks  = read32(chanBase + SFW_XOFF_NCHUNKS);
+
+	if (nChunks == 0 || nChunks > 8)
+		return 0;
+
+	u16 written = 0;
+	u32 i;
+	for (i = 0; i < nChunks && written < maxLen; i++)
+	{
+		u8 *chunkN = (u8*)(chanBase + SFW_XOFF_CHUNKS + i * SFW_CHUNK_SIZE);
+		u16 copyLen = SFW_CHUNK_DATA;
+		if (written + copyLen > maxLen)
+			copyLen = maxLen - written;
+		memcpy(dest + written, chunkN + 2, copyLen);
+		written += copyLen;
+	}
+
+	return written;
+}
+
 void completeFile(FIL *file, SlpGameReader *reader, u32 writtenByteCount)
 {
-	u8 footer[FOOTER_BUFFER_LENGTH];
+	static u8 footer[FOOTER_BUFFER_LENGTH];
 	u32 writePos = 0;
 
 	// Write opener
@@ -169,9 +248,52 @@ void completeFile(FIL *file, SlpGameReader *reader, u32 writtenByteCount)
 	memcpy(&footer[writePos], SlippiGetConsoleNick(), nickLen);
 	writePos += nickLen;
 
-	// Write closing
+	// Write players with initial poll data
+	u8 playersOpener[] = {'U', 7, 'p', 'l', 'a', 'y', 'e', 'r', 's', '{'};
+	writeLen = sizeof(playersOpener);
+	memcpy(&footer[writePos], playersOpener, writeLen);
+	writePos += writeLen;
+
+	// read controller metadata from shared memory
+	sync_before_read((void*)SFW_EXTRA_DATA_ADDR, 4 * SFW_XDATA_STRIDE);
+	static u8 dataBuf[1024];
+	int ch;
+	for (ch = 0; ch < 4; ch++)
+	{
+		u32 addr = SFW_EXTRA_DATA_ADDR + ch * SFW_XDATA_STRIDE;
+		u32 calls = read32(addr + 0x04);
+		if (calls == 0)
+			continue;
+
+		u32 tag = read32(addr + 0x00);
+		if (tag != 0xCA110000)
+			continue;
+
+		/* Reassemble data from raw chunks */
+		u16 dataLen = reassembleControllerMetadata(addr, dataBuf, sizeof(dataBuf));
+
+		/* Validate: must be a flat UBJSON dict of strings */
+		u16 validLen = validateUbjsonStringDict(dataBuf, dataLen);
+		if (validLen == 0)
+			continue;
+
+		/* Overhead: key(3) + validLen + closing(26) must fit */
+		if (writePos + 3 + validLen + 26 > FOOTER_BUFFER_LENGTH)
+			break;
+
+		/* Key: port index as single char "0"-"3" */
+		footer[writePos++] = 'U';
+		footer[writePos++] = 1;
+		footer[writePos++] = '0' + ch;
+
+		/* Embed validated UBJSON object directly (already includes { and }) */
+		memcpy(&footer[writePos], dataBuf, validLen);
+		writePos += validLen;
+	}
+	footer[writePos++] = '}';  /* close players */
+
+	// Write closing (playedOn + close metadata + close root)
 	u8 closing[] = {
-		'U', 7, 'p', 'l', 'a', 'y', 'e', 'r', 's', '{', '}',
 		'U', 8, 'p', 'l', 'a', 'y', 'e', 'd', 'O', 'n', 'S', 'U',
 		10, 'n', 'i', 'n', 't', 'e', 'n', 'd', 'o', 'n', 't',
 		'}', '}'};

--- a/kernel/SlippiFileWriter.c
+++ b/kernel/SlippiFileWriter.c
@@ -21,10 +21,10 @@
 
 // Shared memory for CMD 0xA0xx controller metadata (ARM physical)
 #define SFW_EXTRA_DATA_ADDR  0x13080020
-#define SFW_XDATA_STRIDE     0x0410
+#define SFW_XDATA_STRIDE     0x02B0
 #define SFW_XOFF_NCHUNKS     0x08
 #define SFW_XOFF_CHUNKS      0x10
-#define SFW_CHUNK_SIZE       128
+#define SFW_CHUNK_SIZE       80
 // INLNGTH=80 minus 2-byte header per chunk
 #define SFW_CHUNK_DATA        78
 

--- a/kernel/asm/SIGetTypeControllerMetadata.S
+++ b/kernel/asm/SIGetTypeControllerMetadata.S
@@ -23,7 +23,8 @@
 #    +0x230  chunk[7]   80 bytes  (raw CMD 0xA007 response)
 #    +0x290  dbg_iobuf0 u32
 #    +0x294  dbg_cmdidx u32
-#    +0x298  dbg_id     12 bytes (3 words, reserved; previously CMD 0x00 probe)
+#    +0x298  attempts   u32   (count of SI-work runs; hook fast-exits when >= 2)
+#    +0x29C  reserved   2 words
 #
 #  Chan N base = EXTRA_DATA_BASE + 0x20 + (N * 0x2B0)
 
@@ -40,9 +41,10 @@
 .set XOFF_CHUNKS,        0x10     # 8 chunks × 80 bytes = 640 (0x280)
 .set XOFF_DBG_IOBUF0,    0x290
 .set XOFF_DBG_CMDIDX,    0x294
-.set XOFF_DBG_ID,        0x298    # reserved (was CMD 0x00 identity probe result)
+.set XOFF_ATTEMPTS,      0x298    # number of SI-work runs; hook fast-exits when >= MAX_ATTEMPTS
 .set CHUNK_SIZE,          80
 .set MAX_CHUNKS,          8
+.set MAX_ATTEMPTS,        2
 
 SIGetTypeControllerMetadata:
     lwz     r31, -0x5A68(r13)
@@ -68,6 +70,14 @@ SIGetTypeControllerMetadata:
     mulli   r6, r31, CHAN_STRIDE     # chan * 688 = chan * 0x2B0
     addi    r6, r6, CHAN_BASE_OFF
     add     r5, r5, r6
+
+    # Fast-exit if we've already done MAX_ATTEMPTS SI runs on this channel.
+    # After two tries the SDK's retry loop will keep firing this callback as
+    # the controller cycles err=-1/0, but there's no point repeatedly
+    # disturbing the SI bus — a real RP2040 will have answered by now.
+    lwz     r9, XOFF_ATTEMPTS(r5)
+    cmpwi   r9, MAX_ATTEMPTS
+    bge     .Lcap_exit
 
     # r6 = COMCSR address (constant)
     lis     r6, SI_HW_COMCSR@h
@@ -269,6 +279,12 @@ SIGetTypeControllerMetadata:
     stw     r9, 0(r6)
     eieio
 
+    # Bump attempt counter (only on paths that actually did SI work).
+    lwz     r9, XOFF_ATTEMPTS(r5)
+    addi    r9, r9, 1
+    stw     r9, XOFF_ATTEMPTS(r5)
+
+.Lcap_exit:
     lwz     r9, XOFF_CALLS(r5)
     addi    r9, r9, 1
     stw     r9, XOFF_CALLS(r5)

--- a/kernel/asm/SIGetTypeControllerMetadata.S
+++ b/kernel/asm/SIGetTypeControllerMetadata.S
@@ -1,0 +1,317 @@
+#include <asm.h>
+.include "constants.inc"
+
+#  Hooked inside PADOriginCallback at 0x0034CF4C via PatchBL.
+#  Replaces "lwz r31, -0x5A68(r13)" (load ResettingChan).
+#
+#  Sends CMD 0xA000, reads response. Every response has:
+#    byte 0: total number of SI transfers (1-8)
+#    byte 1: which transfer this is (0-based, 0-7)
+#  If total > 8 or current >= total, treat as normal controller (abort).
+#  Then sends 0xA001 .. 0xA0(total-1) to collect remaining chunks.
+#  Each chunk is 80 bytes; data starts at byte 2 (78 data bytes/chunk).
+#  Max total data = 8 * 78 = 624 bytes.
+#
+#  Per-channel shared memory layout (base +0x20, stride 0x410):
+#    +0x000  tag        u32   (TAG_OK / TAG_NODATA / error tags)
+#    +0x004  calls      u32   (monotonic "data ready" counter)
+#    +0x008  n_chunks   u32   (number of 80-byte chunks, 1-8)
+#    +0x00C  dbg_comcsr u32   (raw COMCSR value on error/completion)
+#    +0x010  chunk[0]   80 bytes  (raw CMD 0xA000 response)
+#    +0x060  chunk[1]   80 bytes  (raw CMD 0xA001 response)
+#    ...
+#    +0x390  chunk[7]   80 bytes  (raw CMD 0xA007 response)
+#
+#  Chan N base = EXTRA_DATA_BASE + 0x20 + (N * 0x410)
+
+.set SI_HW_COMCSR,       0xCD806434
+.set SI_HW_IO_BUF,       0xCD806480
+.set EXTRA_DATA_BASE,    0xD3080000
+
+.set CHAN_BASE_OFF,       0x20
+.set CHAN_STRIDE,         0x0410
+.set XOFF_TAG,           0x00
+.set XOFF_CALLS,         0x04
+.set XOFF_NCHUNKS,       0x08
+.set XOFF_DBG_COMCSR,    0x0C
+.set XOFF_CHUNKS,        0x10
+.set XOFF_DBG_IOBUF0,    0x400
+.set XOFF_DBG_CMDIDX,    0x404
+.set XOFF_DBG_ID,        0x408        # CMD 0x00 identity probe result (3 words)
+.set CHUNK_SIZE,          80
+.set MAX_CHUNKS,          8
+
+SIGetTypeControllerMetadata:
+    lwz     r31, -0x5A68(r13)
+
+    stwu    r1, -48(r1)
+    stw     r5, 8(r1)
+    mfcr    r5
+    stw     r5, 40(r1)          # save CR before any compare
+
+    cmpwi   r31, 3
+    bgt     .Learly_restore     # channels > 3: restore CR/r5 and return
+
+    stw     r6, 12(r1)
+    stw     r7, 16(r1)
+    stw     r8, 20(r1)
+    stw     r9, 24(r1)
+    stw     r10, 28(r1)
+    stw     r11, 32(r1)
+    stw     r12, 36(r1)
+
+    # r5 = per-channel shared memory base
+    lis     r5, EXTRA_DATA_BASE@h
+    slwi    r6, r31, 10             # chan * 1024
+    slwi    r7, r31, 4              # chan * 16
+    add     r6, r6, r7              # chan * 1040 = chan * 0x410
+    addi    r6, r6, CHAN_BASE_OFF
+    add     r5, r5, r6
+
+    # r6 = COMCSR address (constant)
+    lis     r6, SI_HW_COMCSR@h
+    ori     r6, r6, SI_HW_COMCSR@l
+
+    # === Drain any in-flight transfer ===
+    li      r10, 0
+.Ldrain_loop:
+    lwz     r7, 0(r6)
+    eieio
+    andi.   r9, r7, 1
+    beq     .Ldrain_done
+    addi    r10, r10, 1
+    cmpwi   r10, 20000
+    blt     .Ldrain_loop
+
+    stw     r7, XOFF_DBG_COMCSR(r5)
+    li      r9, -1
+    stw     r9, XOFF_DBG_CMDIDX(r5)
+    lis     r9, 0xDEAD
+    ori     r9, r9, 0x0004
+    stw     r9, XOFF_TAG(r5)
+    b       .Lrestore
+
+.Ldrain_done:
+    andis.  r9, r7, 0x8000
+    beq     .Lsetup
+    lis     r9, 0x8000
+    stw     r9, 0(r6)
+    eieio
+
+.Lsetup:
+    # r8 = IO_BUF address (constant)
+    lis     r8, SI_HW_IO_BUF@h
+    ori     r8, r8, SI_HW_IO_BUF@l
+    li      r12, 0                  # cmd_idx = 0
+    li      r11, 0                  # expected_total (set after first response)
+    li      r9, 0
+    stw     r9, XOFF_DBG_COMCSR(r5) # init: 0 = no COMERR
+
+    # === Diagnostic: CMD 0x00 identity probe ===
+    # Send 1-byte CMD 0x00, expect 3 bytes back (24-bit type ID)
+    lis     r9, 0x0000
+    stw     r9, 0(r8)              # IO_BUF[0] = 0x00000000
+    eieio
+    # COMCSR: TCINT_clear | OUTLNGTH=1 | INLNGTH=3 | chan | TSTART
+    lis     r9, 0x8001
+    ori     r9, r9, 0x0301         # INLNGTH=3, TSTART=1
+    slwi    r7, r31, 1
+    or      r9, r9, r7             # chan bits
+    stw     r9, 0(r6)
+    eieio
+
+    li      r10, 0
+.Lid_poll:
+    lwz     r7, 0(r6)
+    eieio
+    andis.  r9, r7, 0x8000
+    bne     .Lid_done
+    addi    r10, r10, 1
+    cmpwi   r10, 20000
+    blt     .Lid_poll
+    # Timeout — store 0xDEAD as id result
+    lis     r9, 0xDEAD
+    stw     r9, XOFF_DBG_ID(r5)
+    li      r9, 0
+    stw     r9, XOFF_DBG_ID+4(r5)
+    stw     r7, XOFF_DBG_ID+8(r5)  # raw COMCSR
+    b       .Lid_clear
+
+.Lid_done:
+    # Store COMCSR, IO_BUF[0] (contains type ID), IO_BUF[1]
+    stw     r7, XOFF_DBG_ID+8(r5)  # COMCSR from identity probe
+    lwz     r9, 0(r8)
+    eieio
+    stw     r9, XOFF_DBG_ID(r5)    # IO_BUF[0] = type ID bits
+    lwz     r9, 4(r8)
+    stw     r9, XOFF_DBG_ID+4(r5)  # IO_BUF[1]
+
+.Lid_clear:
+    # Clear TCINT
+    lis     r9, 0x8000
+    stw     r9, 0(r6)
+    eieio
+
+    # ========== Command loop ==========
+.Lcmd_loop:
+    # Write CMD 0xA0xx to IO_BUF word 0 (xx = cmd_idx)
+    lis     r9, 0xA000              # 0xA0000000
+    slwi    r10, r12, 16            # cmd_idx << 16
+    or      r9, r9, r10
+    stw     r9, 0(r8)
+    eieio
+
+    # COMCSR: TCINT_clear | OUTLNGTH=2 | INLNGTH=80 | chan | TSTART
+    # INLNGTH field: 7 bits (14-8). Max reliable value.
+    lis     r9, 0x8002
+    ori     r9, r9, 0x5001
+    slwi    r7, r31, 1
+    or      r9, r9, r7
+    stw     r9, 0(r6)
+    eieio
+
+    # Poll for TCINT
+    li      r10, 0
+.Lpoll:
+    lwz     r7, 0(r6)
+    eieio
+    andis.  r9, r7, 0x8000
+    bne     .Lxfer_done
+    addi    r10, r10, 1
+    cmpwi   r10, 20000
+    blt     .Lpoll
+
+    # Timeout — store debug info
+    stw     r7, XOFF_DBG_COMCSR(r5)
+    lwz     r9, 0(r8)
+    stw     r9, XOFF_DBG_IOBUF0(r5)
+    stw     r12, XOFF_DBG_CMDIDX(r5)
+    lis     r9, 0x8000
+    stw     r9, 0(r6)
+    eieio
+    lis     r9, 0xDEAD
+    ori     r9, r9, 0x0001
+    stw     r9, XOFF_TAG(r5)
+    b       .Lrestore
+
+.Lxfer_done:
+    # Check COMERR
+    andis.  r9, r7, 0x2000
+    beq     .Lno_comerr
+
+    # COMERR on first probe (cmd_idx==0) → normal GC controller, treat as NODATA
+    cmpwi   r12, 0
+    beq     .Lcomerr_as_nodata
+    b       .Lstore_comerr
+
+.Lcomerr_as_nodata:
+    # Store COMCSR (has COMERR bit) so ARM side can see it was COMERR
+    stw     r7, XOFF_DBG_COMCSR(r5)
+    # Clear TCINT
+    lis     r9, 0x8000
+    stw     r9, 0(r6)
+    eieio
+    b       .Lnodata
+
+.Lno_comerr:
+
+    # Clear TCINT
+    lis     r9, 0x8000
+    stw     r9, 0(r6)
+    eieio
+
+    # Validate header bytes from IO_BUF word 0 (still valid after copy)
+    lwz     r9, 0(r8)
+    eieio
+    # r10 = byte 0 (total), r7 = byte 1 (current)
+    srwi    r10, r9, 24            # total = byte 0
+    rlwinm  r7, r9, 16, 24, 31    # current = byte 1
+
+    # If total < 1 or total > 8 → not an RP2040, abort with NODATA
+    cmpwi   r10, 1
+    blt     .Lnodata
+    cmpwi   r10, MAX_CHUNKS
+    bgt     .Lnodata
+
+    # If current != cmd_idx → protocol mismatch, abort with NODATA
+    cmpw    r7, r12
+    bne     .Lnodata
+
+    # First response: save expected total in r11
+    cmpwi   r12, 0
+    bne     .Lskip_save_total
+    mr      r11, r10
+.Lskip_save_total:
+
+    # Verify total matches what first response said
+    cmpw    r10, r11
+    bne     .Lnodata
+
+    # Copy 128 bytes (32 words) from IO_BUF to chunk[cmd_idx]
+    slwi    r7, r12, 7              # cmd_idx * 128
+    addi    r7, r7, XOFF_CHUNKS
+    add     r7, r5, r7              # dest ptr
+    li      r10, 0
+.Lcopy:
+    lwzx    r9, r8, r10
+    stwx    r9, r7, r10
+    addi    r10, r10, 4
+    cmpwi   r10, CHUNK_SIZE
+    blt     .Lcopy
+
+    # Check if more chunks needed
+    addi    r12, r12, 1
+    cmpw    r12, r11
+    blt     .Lcmd_loop
+
+    # All chunks received — store success
+    stw     r11, XOFF_NCHUNKS(r5)
+    lis     r9, 0xCA11
+    stw     r9, XOFF_TAG(r5)
+    b       .Lrestore
+
+.Lnodata:
+    # Normal controller or protocol mismatch — store IO_BUF[0] for debug
+    lwz     r9, 0(r8)
+    stw     r9, XOFF_DBG_IOBUF0(r5)
+    stw     r12, XOFF_DBG_CMDIDX(r5)
+    lis     r9, 0xCA11
+    ori     r9, r9, 0x0001
+    stw     r9, XOFF_TAG(r5)
+    li      r9, 0
+    stw     r9, XOFF_NCHUNKS(r5)
+    b       .Lrestore
+
+.Lstore_comerr:
+    # Store debug: COMCSR, IO_BUF[0], cmd_idx
+    stw     r7, XOFF_DBG_COMCSR(r5)
+    lwz     r9, 0(r8)
+    eieio
+    stw     r9, XOFF_DBG_IOBUF0(r5)
+    stw     r12, XOFF_DBG_CMDIDX(r5)
+    # Clear TCINT
+    lis     r9, 0x8000
+    stw     r9, 0(r6)
+    eieio
+    lis     r9, 0xDEAD
+    ori     r9, r9, 0x0003
+    stw     r9, XOFF_TAG(r5)
+
+.Lrestore:
+    lwz     r9, XOFF_CALLS(r5)
+    addi    r9, r9, 1
+    stw     r9, XOFF_CALLS(r5)
+
+    lwz     r6, 12(r1)
+    lwz     r7, 16(r1)
+    lwz     r8, 20(r1)
+    lwz     r9, 24(r1)
+    lwz     r10, 28(r1)
+    lwz     r11, 32(r1)
+    lwz     r12, 36(r1)
+.Learly_restore:
+    lwz     r5, 40(r1)          # restore CR
+    mtcr    r5
+    lwz     r5, 8(r1)
+    addi    r1, r1, 48
+    blr

--- a/kernel/asm/SIGetTypeControllerMetadata.S
+++ b/kernel/asm/SIGetTypeControllerMetadata.S
@@ -12,7 +12,7 @@
 #  Each chunk is 80 bytes; data starts at byte 2 (78 data bytes/chunk).
 #  Max total data = 8 * 78 = 624 bytes.
 #
-#  Per-channel shared memory layout (base +0x20, stride 0x410):
+#  Per-channel shared memory layout (base +0x20, stride 0x2B0):
 #    +0x000  tag        u32   (TAG_OK / TAG_NODATA / error tags)
 #    +0x004  calls      u32   (monotonic "data ready" counter)
 #    +0x008  n_chunks   u32   (number of 80-byte chunks, 1-8)
@@ -20,24 +20,27 @@
 #    +0x010  chunk[0]   80 bytes  (raw CMD 0xA000 response)
 #    +0x060  chunk[1]   80 bytes  (raw CMD 0xA001 response)
 #    ...
-#    +0x390  chunk[7]   80 bytes  (raw CMD 0xA007 response)
+#    +0x230  chunk[7]   80 bytes  (raw CMD 0xA007 response)
+#    +0x290  dbg_iobuf0 u32
+#    +0x294  dbg_cmdidx u32
+#    +0x298  dbg_id     12 bytes (3 words)
 #
-#  Chan N base = EXTRA_DATA_BASE + 0x20 + (N * 0x410)
+#  Chan N base = EXTRA_DATA_BASE + 0x20 + (N * 0x2B0)
 
 .set SI_HW_COMCSR,       0xCD806434
 .set SI_HW_IO_BUF,       0xCD806480
 .set EXTRA_DATA_BASE,    0xD3080000
 
 .set CHAN_BASE_OFF,       0x20
-.set CHAN_STRIDE,         0x0410
+.set CHAN_STRIDE,         0x02B0   # 688 bytes per channel
 .set XOFF_TAG,           0x00
 .set XOFF_CALLS,         0x04
 .set XOFF_NCHUNKS,       0x08
 .set XOFF_DBG_COMCSR,    0x0C
-.set XOFF_CHUNKS,        0x10
-.set XOFF_DBG_IOBUF0,    0x400
-.set XOFF_DBG_CMDIDX,    0x404
-.set XOFF_DBG_ID,        0x408        # CMD 0x00 identity probe result (3 words)
+.set XOFF_CHUNKS,        0x10     # 8 chunks × 80 bytes = 640 (0x280)
+.set XOFF_DBG_IOBUF0,    0x290
+.set XOFF_DBG_CMDIDX,    0x294
+.set XOFF_DBG_ID,        0x298    # CMD 0x00 identity probe result (3 words)
 .set CHUNK_SIZE,          80
 .set MAX_CHUNKS,          8
 
@@ -62,9 +65,7 @@ SIGetTypeControllerMetadata:
 
     # r5 = per-channel shared memory base
     lis     r5, EXTRA_DATA_BASE@h
-    slwi    r6, r31, 10             # chan * 1024
-    slwi    r7, r31, 4              # chan * 16
-    add     r6, r6, r7              # chan * 1040 = chan * 0x410
+    mulli   r6, r31, CHAN_STRIDE     # chan * 688 = chan * 0x2B0
     addi    r6, r6, CHAN_BASE_OFF
     add     r5, r5, r6
 
@@ -247,8 +248,8 @@ SIGetTypeControllerMetadata:
     cmpw    r10, r11
     bne     .Lnodata
 
-    # Copy 128 bytes (32 words) from IO_BUF to chunk[cmd_idx]
-    slwi    r7, r12, 7              # cmd_idx * 128
+    # Copy 80 bytes (20 words) from IO_BUF to chunk[cmd_idx]
+    mulli   r7, r12, CHUNK_SIZE     # cmd_idx * 80
     addi    r7, r7, XOFF_CHUNKS
     add     r7, r5, r7              # dest ptr
     li      r10, 0

--- a/kernel/asm/SIGetTypeControllerMetadata.S
+++ b/kernel/asm/SIGetTypeControllerMetadata.S
@@ -23,7 +23,7 @@
 #    +0x230  chunk[7]   80 bytes  (raw CMD 0xA007 response)
 #    +0x290  dbg_iobuf0 u32
 #    +0x294  dbg_cmdidx u32
-#    +0x298  dbg_id     12 bytes (3 words)
+#    +0x298  dbg_id     12 bytes (3 words, reserved; previously CMD 0x00 probe)
 #
 #  Chan N base = EXTRA_DATA_BASE + 0x20 + (N * 0x2B0)
 
@@ -40,7 +40,7 @@
 .set XOFF_CHUNKS,        0x10     # 8 chunks × 80 bytes = 640 (0x280)
 .set XOFF_DBG_IOBUF0,    0x290
 .set XOFF_DBG_CMDIDX,    0x294
-.set XOFF_DBG_ID,        0x298    # CMD 0x00 identity probe result (3 words)
+.set XOFF_DBG_ID,        0x298    # reserved (was CMD 0x00 identity probe result)
 .set CHUNK_SIZE,          80
 .set MAX_CHUNKS,          8
 
@@ -108,50 +108,11 @@ SIGetTypeControllerMetadata:
     li      r9, 0
     stw     r9, XOFF_DBG_COMCSR(r5) # init: 0 = no COMERR
 
-    # === Diagnostic: CMD 0x00 identity probe ===
-    # Send 1-byte CMD 0x00, expect 3 bytes back (24-bit type ID)
-    lis     r9, 0x0000
-    stw     r9, 0(r8)              # IO_BUF[0] = 0x00000000
-    eieio
-    # COMCSR: TCINT_clear | OUTLNGTH=1 | INLNGTH=3 | chan | TSTART
-    lis     r9, 0x8001
-    ori     r9, r9, 0x0301         # INLNGTH=3, TSTART=1
-    slwi    r7, r31, 1
-    or      r9, r9, r7             # chan bits
-    stw     r9, 0(r6)
-    eieio
-
-    li      r10, 0
-.Lid_poll:
-    lwz     r7, 0(r6)
-    eieio
-    andis.  r9, r7, 0x8000
-    bne     .Lid_done
-    addi    r10, r10, 1
-    cmpwi   r10, 20000
-    blt     .Lid_poll
-    # Timeout — store 0xDEAD as id result
-    lis     r9, 0xDEAD
-    stw     r9, XOFF_DBG_ID(r5)
-    li      r9, 0
-    stw     r9, XOFF_DBG_ID+4(r5)
-    stw     r7, XOFF_DBG_ID+8(r5)  # raw COMCSR
-    b       .Lid_clear
-
-.Lid_done:
-    # Store COMCSR, IO_BUF[0] (contains type ID), IO_BUF[1]
-    stw     r7, XOFF_DBG_ID+8(r5)  # COMCSR from identity probe
-    lwz     r9, 0(r8)
-    eieio
-    stw     r9, XOFF_DBG_ID(r5)    # IO_BUF[0] = type ID bits
-    lwz     r9, 4(r8)
-    stw     r9, XOFF_DBG_ID+4(r5)  # IO_BUF[1]
-
-.Lid_clear:
-    # Clear TCINT
-    lis     r9, 0x8000
-    stw     r9, 0(r6)
-    eieio
+    # NOTE: No CMD 0x00 identity probe — issuing an extra SI transaction
+    # inside the PADOriginCallback ISR perturbs the bus for normal GC
+    # controllers and delays the SDK's subsequent SIEnablePolling. The first
+    # CMD 0xA0xx below is itself the probe: a real GC controller will reply
+    # with COMERR which is caught in .Lcomerr_as_nodata.
 
     # ========== Command loop ==========
 .Lcmd_loop:
@@ -299,6 +260,15 @@ SIGetTypeControllerMetadata:
     stw     r9, XOFF_TAG(r5)
 
 .Lrestore:
+    # Restore SI error state to entry: on entry COMERR/TCINT are clean
+    # (PADOriginCallback was invoked with error=0 and the SDK ISR cleared
+    # TCINT before dispatch), so unconditionally W1C both bits in COMCSR.
+    # This prevents any sticky COMERR from our CMD 0xA0 probes from
+    # being observed by the SDK's subsequent SIEnablePolling.
+    lis     r9, 0xA000              # 0x80000000 (TCINT W1C) | 0x20000000 (COMERR W1C)
+    stw     r9, 0(r6)
+    eieio
+
     lwz     r9, XOFF_CALLS(r5)
     addi    r9, r9, 1
     stw     r9, XOFF_CALLS(r5)

--- a/loader/source/ppc/PADReadGC.c
+++ b/loader/source/ppc/PADReadGC.c
@@ -36,13 +36,6 @@ static u32 PrevAdapterChannel3 = 0;
 static u32 PrevAdapterChannel4 = 0;
 static u32 PrevDRCButton = 0;
 
-static u32 PadWasConnected[NIN_CFG_MAXPAD] = {0};
-
-// Shared memory for signaling the kernel
-#define SI_EXTRA_REQUEST  0x93003500  // PPC writes here
-// Layout: 4 bytes per channel
-// 0 = idle, 1 = "new controller, please read extra data", 2 = "kernel done"
-
 #define DRC_SWAP (1<<16)
 
 const s8 DEADZONE = 0x1A;
@@ -227,7 +220,6 @@ u32 _start(u32 calledByGame)
 			Pad[chan].button = ((PADButtonsStick>>16)&0xFFFF);
 			if(Pad[chan].button & 0x8000) /* controller not enabled */
 			{
-				PadWasConnected[chan] = 0;
 				PADBarrelEnabled[chan] = 1; //if wavebird disconnects it cant reconnect
 				u32 psize = sizeof(PADStatus)-1; //dont set error twice
 				vu8 *CurPad = (vu8*)(&Pad[chan]);
@@ -239,19 +231,6 @@ u32 _start(u32 calledByGame)
 				}
 				continue;
 			}
-
-			// Controller is connected
-			if(!PadWasConnected[chan])
-			{
-			    // New controller just appeared!
-			    PadWasConnected[chan] = 1;
-
-			    // Signal the kernel to read extra data for this channel
-			    vu32 *request = (vu32*)(SI_EXTRA_REQUEST + (chan * 4));
-			    *request = 1;
-			    asm volatile("dcbf 0, %0 ; sync" : : "r"(request));
-			}
-
 			used |= (1<<chan);
 
 			/* save IsBarrel status */

--- a/loader/source/ppc/PADReadGC.c
+++ b/loader/source/ppc/PADReadGC.c
@@ -36,6 +36,13 @@ static u32 PrevAdapterChannel3 = 0;
 static u32 PrevAdapterChannel4 = 0;
 static u32 PrevDRCButton = 0;
 
+static u32 PadWasConnected[NIN_CFG_MAXPAD] = {0};
+
+// Shared memory for signaling the kernel
+#define SI_EXTRA_REQUEST  0x93003500  // PPC writes here
+// Layout: 4 bytes per channel
+// 0 = idle, 1 = "new controller, please read extra data", 2 = "kernel done"
+
 #define DRC_SWAP (1<<16)
 
 const s8 DEADZONE = 0x1A;
@@ -220,6 +227,7 @@ u32 _start(u32 calledByGame)
 			Pad[chan].button = ((PADButtonsStick>>16)&0xFFFF);
 			if(Pad[chan].button & 0x8000) /* controller not enabled */
 			{
+				PadWasConnected[chan] = 0;
 				PADBarrelEnabled[chan] = 1; //if wavebird disconnects it cant reconnect
 				u32 psize = sizeof(PADStatus)-1; //dont set error twice
 				vu8 *CurPad = (vu8*)(&Pad[chan]);
@@ -231,6 +239,19 @@ u32 _start(u32 calledByGame)
 				}
 				continue;
 			}
+
+			// Controller is connected
+			if(!PadWasConnected[chan])
+			{
+			    // New controller just appeared!
+			    PadWasConnected[chan] = 1;
+
+			    // Signal the kernel to read extra data for this channel
+			    vu32 *request = (vu32*)(SI_EXTRA_REQUEST + (chan * 4));
+			    *request = 1;
+			    asm volatile("dcbf 0, %0 ; sync" : : "r"(request));
+			}
+
 			used |= (1<<chan);
 
 			/* save IsBarrel status */


### PR DESCRIPTION
A patch like this could allow users to have their tags, startgg account, ect to be included in the resulting slippi file automatically. It could also set their preferred four character name entry.

A few more features need to be implemented for this to be beneficial:
- decode the extra data into the actual attributes
- pipe the data into the slippi file
- pipe the name entry to some ssbm gecko code

And then for it to actually be adopted it would need phob support:
- Support SI commands for getting and setting the extra data

And for easy distribution it could be possible to modify the gc pocket firmware to set the extra data over SI, so that you don't even have to open the controller to set it.

In tandem with the esp32 ftp server in the works, this could help significantly with automating TO work.