### PR TITLE
Stop excessive replay writes to improve flash storage longevity

### DIFF
--- a/kernel/SlippiFileWriter.c
+++ b/kernel/SlippiFileWriter.c
@@ -259,15 +259,24 @@ static u32 SlippiHandlerThread(void *arg)
 
 					// only attempt to mount once, user can retry by re-inserting the device.
 					failedToMount = true;
+					continue;
 				}
-				else
-				{
-					// ignore anything already in the buffer. users should not expect to record a
-					// game if the usb device is inserted after game start.
-					memReadPos = SlippiRestoreReadPos();
 
-					mounted = true;
+				// Create folder if it doesn't exist yet
+				FRESULT mkdirResult = f_mkdir_secondary_drive("/Slippi");
+				if (mkdirResult != FR_OK && mkdirResult != FR_EXIST)
+				{
+					dbgprintf("Slippi: failed to mkdir: /Slippi, errno: %d\r\n", mkdirResult);
+
+					// only attempt to mount once, user can retry by re-inserting the device.
+					failedToMount = true;
+					continue;
 				}
+
+				// ignore anything already in the buffer. users should not expect to record a
+				// game if the usb device is inserted after game start.
+				memReadPos = SlippiRestoreReadPos();
+				mounted = true;
 			}
 			if (!mounted)
 				continue;
@@ -325,14 +334,6 @@ static u32 SlippiHandlerThread(void *arg)
 						break;
 					}
 					currentFileOpen = false;
-				}
-
-				// Create folder if it doesn't exist yet
-				FRESULT mkdirResult = f_mkdir_secondary_drive("/Slippi");
-				if (mkdirResult != FR_OK && mkdirResult != FR_EXIST)
-				{
-					dbgprintf("Slippi: failed to mkdir: /Slippi, errno: %d\r\n", mkdirResult);
-					break;
 				}
 
 				dbgprintf("Creating File...\r\n");

--- a/kernel/SlippiFileWriter.c
+++ b/kernel/SlippiFileWriter.c
@@ -121,10 +121,9 @@ void writeHeader(FIL *file)
 
 	u32 wrote;
 	f_write(file, header, sizeof(header), &wrote);
-	f_sync(file);
 }
 
-void completeFile(FIL *file, SlpGameReader *reader, u32 writtenByteCount)
+FRESULT completeFile(FIL *file, SlpGameReader *reader, u32 writtenByteCount)
 {
 	u8 footer[FOOTER_BUFFER_LENGTH];
 	u32 writePos = 0;
@@ -181,12 +180,16 @@ void completeFile(FIL *file, SlpGameReader *reader, u32 writtenByteCount)
 
 	// Write footer
 	u32 wrote;
-	f_write(file, footer, writePos, &wrote);
-	f_sync(file);
-
-	f_lseek(file, 11);
-	FRESULT fileWriteResult = f_write(file, &writtenByteCount, 4, &wrote);
-	f_sync(file);
+	FRESULT fRes = f_write(file, footer, writePos, &wrote);
+	if (fRes != FR_OK) {
+		return fRes;
+	}
+	fRes = f_lseek(file, 11);
+	if (fRes != FR_OK) {
+		return fRes;
+	}
+	fRes = f_write(file, &writtenByteCount, 4, &wrote);
+	return fRes;
 }
 
 static u32 SlippiHandlerThread(void *arg)
@@ -255,6 +258,13 @@ static u32 SlippiHandlerThread(void *arg)
 			// For specific errors, bytes will still be read. Not continueing to deal with those
 		}
 
+		if (reader.lastReadResult.bytesRead < 4096 && !(hasFile && reader.lastReadResult.isGameEnd))
+		{
+			if (replaysLED)
+				flashLED();
+			continue;
+		}
+
 		if (reader.lastReadResult.isNewGame)
 		{
 			// Create folder if it doesn't exist yet
@@ -272,19 +282,10 @@ static u32 SlippiHandlerThread(void *arg)
 				mdelay(LED_FLASH_TIME_MS - THREAD_CYCLE_TIME_MS - 100); // short enough so we can recover with running out of LED time.
 				continue;
 			}
-			if (replaysLED)
-				flashLED();
 
 			hasFile = true;
 			writtenByteCount = 0;
 			writeHeader(&currentFile);
-		}
-
-		if (reader.lastReadResult.bytesRead == 0)
-		{
-			if (replaysLED)
-				flashLED();
-			continue;
 		}
 
 		// dbgprintf("Bytes read: %d\r\n", reader.lastReadResult.bytesRead);
@@ -301,23 +302,25 @@ static u32 SlippiHandlerThread(void *arg)
 
 		UINT wrote;
 		FRESULT writeResult = f_write(&currentFile, readBuf, reader.lastReadResult.bytesRead, &wrote);
-		if (replaysLED && writeResult == FR_OK && wrote > 0)
-			flashLED();
-		f_sync(&currentFile);
-
 		if (wrote == 0)
 			continue;
 
-		// Only increment mem read position when the data is correctly written
+		// Only increment mem read position when some data is correctly written
 		memReadPos += wrote;
 		writtenByteCount += wrote;
 
-		if (reader.lastReadResult.isGameEnd)
+		if (reader.lastReadResult.isGameEnd && writeResult == FR_OK)
 		{
 			dbgprintf("Completing File...\r\n");
-			completeFile(&currentFile, &reader, writtenByteCount);
-			f_close(&currentFile);
+			FRESULT completeResult = completeFile(&currentFile, &reader, writtenByteCount);
+			FRESULT closeResult = f_close(&currentFile);
 			hasFile = false;
+			if (replaysLED && writeResult == FR_OK && completeResult == FR_OK && closeResult == FR_OK)
+				flashLED();
+		} else {
+			FRESULT syncResult = f_sync(&currentFile);
+			if (replaysLED && writeResult == FR_OK && syncResult == FR_OK)
+				flashLED();
 		}
 	}
 

--- a/kernel/SlippiFileWriter.c
+++ b/kernel/SlippiFileWriter.c
@@ -9,10 +9,10 @@
 #include "Config.h"
 #include "usbstorage.h"
 
-// Game can transfer at most 784 bytes / frame
-// That means 4704 bytes every 100 ms. Let's aim to handle
-// double that, making our read buffer 10000 bytes
-#define READ_BUF_SIZE 10000
+// use common physical sector size so as to write efficiently
+// and not excessively wear out the underlying flash storage
+#define READ_BUF_SIZE 4096
+
 #define THREAD_CYCLE_TIME_MS 100
 #define THREAD_ERROR_TIME_MS 2000
 #define LED_FLASH_TIME_MS 1000
@@ -93,7 +93,7 @@ struct tm
 };
 extern struct tm *gmtime(u32 *time);
 
-char *generateFileName(bool isNewFile)
+char *generateFileName()
 {
 	// // Add game start time
 	// u8 dateTimeStrLength = sizeof "20171015T095717";
@@ -115,15 +115,15 @@ char *generateFileName(bool isNewFile)
 	return pathStr;
 }
 
-void writeHeader(FIL *file)
+FRESULT writeHeader(FIL *file)
 {
 	u8 header[] = {'{', 'U', 3, 'r', 'a', 'w', '[', '$', 'U', '#', 'l', 0, 0, 0, 0};
 
 	u32 wrote;
-	f_write(file, header, sizeof(header), &wrote);
+	return f_write(file, header, sizeof(header), &wrote);
 }
 
-FRESULT completeFile(FIL *file, SlpGameReader *reader, u32 writtenByteCount)
+FRESULT completeFile(FIL *file, s32 lastFrame, u32 writtenByteCount)
 {
 	u8 footer[FOOTER_BUFFER_LENGTH];
 	u32 writePos = 0;
@@ -155,7 +155,7 @@ FRESULT completeFile(FIL *file, SlpGameReader *reader, u32 writtenByteCount)
 	writeLen = sizeof(lastFrameOpener);
 	memcpy(&footer[writePos], lastFrameOpener, writeLen);
 	writePos += writeLen;
-	memcpy(&footer[writePos], &reader->metadata.lastFrame, 4);
+	memcpy(&footer[writePos], &lastFrame, 4);
 	writePos += 4;
 
 	// Write console nickname
@@ -179,17 +179,22 @@ FRESULT completeFile(FIL *file, SlpGameReader *reader, u32 writtenByteCount)
 	writePos += writeLen;
 
 	// Write footer
+	// Always seek first in case there was a previous failure with partial write
+	FRESULT fRes = f_lseek(file, writtenByteCount + 15);
+	if (fRes != FR_OK)
+		return fRes;
+
 	u32 wrote;
-	FRESULT fRes = f_write(file, footer, writePos, &wrote);
-	if (fRes != FR_OK) {
+	fRes = f_write(file, footer, writePos, &wrote);
+	if (fRes != FR_OK)
 		return fRes;
-	}
+
+	// Write length
 	fRes = f_lseek(file, 11);
-	if (fRes != FR_OK) {
+	if (fRes != FR_OK)
 		return fRes;
-	}
-	fRes = f_write(file, &writtenByteCount, 4, &wrote);
-	return fRes;
+
+	return f_write(file, &writtenByteCount, 4, &wrote);
 }
 
 static u32 SlippiHandlerThread(void *arg)
@@ -201,11 +206,13 @@ static u32 SlippiHandlerThread(void *arg)
 	static u64 memReadPos = 0;
 
 	u32 writtenByteCount = 0;
+	s32 lastFrame;
 	driveTimer = read32(HW_TIMER);
 	driveTimerSet = false;
 
 	bool failedToMount = false;
-	bool hasFile = false;
+	bool currentFileOpen = false;
+	bool currentFileValid = false;
 	const bool use_usb = ConfigGetUseUSB() != 1;
 	bool mounted = use_usb ? USBStorage_IsInserted_SlippiThread() : true;
 
@@ -219,10 +226,14 @@ static u32 SlippiHandlerThread(void *arg)
 			if (!USBStorage_IsInserted_SlippiThread())
 			{
 				if (mounted)
+				{
+					// unmount (cannot fail so no need to check return value)
 					f_mount_char(NULL, "usb:", 1);
+				}
 
 				failedToMount = false;
-				hasFile = false;
+				currentFileOpen = false;
+				currentFileValid = false;
 				mounted = false;
 				continue;
 			}
@@ -246,81 +257,133 @@ static u32 SlippiHandlerThread(void *arg)
 				continue;
 		}
 
-		// Read from memory and write to file
-		SlpMemError err = SlippiMemoryRead(&reader, readBuf, READ_BUF_SIZE, memReadPos);
-		if (err)
+		while (1)
 		{
-			if (err == SLP_READ_OVERFLOW)
-				memReadPos = SlippiRestoreReadPos();
-				
-			mdelay(LED_FLASH_TIME_MS + 1000); // we always want LED visibly off if this happens
-			
-			// For specific errors, bytes will still be read. Not continueing to deal with those
-		}
-
-		if (reader.lastReadResult.bytesRead < 4096 && !(hasFile && reader.lastReadResult.isGameEnd))
-		{
-			if (replaysLED)
-				flashLED();
-			continue;
-		}
-
-		if (reader.lastReadResult.isNewGame)
-		{
-			// Create folder if it doesn't exist yet
-			f_mkdir_secondary_drive("/Slippi");
-
-			gameStartTime = GetCurrentTime();
-
-			dbgprintf("Creating File...\r\n");
-			char *fileName = generateFileName(true);
-			// Maybe can remove FA_READ since network thread doesn't share &currentFile
-			FRESULT fileOpenResult = f_open_secondary_drive(&currentFile, fileName, FA_CREATE_ALWAYS | FA_WRITE | FA_READ);
-			if (fileOpenResult != FR_OK)
+			// Read from memory and write to file
+			SlpMemError err = SlippiMemoryRead(&reader, readBuf, READ_BUF_SIZE, memReadPos);
+			if (err)
 			{
-				dbgprintf("Slippi: failed to open file: %s, errno: %d\r\n", fileName, fileOpenResult);
-				mdelay(LED_FLASH_TIME_MS - THREAD_CYCLE_TIME_MS - 100); // short enough so we can recover with running out of LED time.
-				continue;
+				// all possible errors render the current file incompletable, so let's jump ahead
+				currentFileValid = false;
+				memReadPos = SlippiRestoreReadPos();
+				if (currentFileOpen)
+				{
+					FRESULT closeResult = f_close(&currentFile);
+					if (closeResult == FR_OK)
+						currentFileOpen = false;
+				}
+				break;
 			}
 
-			hasFile = true;
-			writtenByteCount = 0;
-			writeHeader(&currentFile);
-		}
+			if (reader.lastReadResult.bytesAvailable < READ_BUF_SIZE && !(currentFileValid && reader.lastReadResult.isGameEnd))
+			{
+				if (replaysLED)
+					flashLED();
+				break;
+			}
 
-		// dbgprintf("Bytes read: %d\r\n", reader.lastReadResult.bytesRead);
+			if (reader.lastReadResult.isNewGame)
+			{
+				if (currentFileValid)
+				{
+					FRESULT completeResult = completeFile(&currentFile, lastFrame, writtenByteCount);
+					if (completeResult != FR_OK)
+					{
+						dbgprintf("Slippi: failed to complete dangling file, errno: %d\r\n", completeResult);
+						break;
+					}
+					currentFileValid = false;
+				}
+				if (currentFileOpen)
+				{
+					FRESULT closeResult = f_close(&currentFile);
+					if (closeResult != FR_OK)
+					{
+						dbgprintf("Slippi: failed to close dangling file, errno: %d\r\n", closeResult);
+						break;
+					}
+					currentFileOpen = false;
+				}
 
-		if (!hasFile)
-		{
-			// we can reach this state if the user inserts a usb device during a game.
-			// skip over and don't write anything until we see the start of a new game
-			if (replaysLED)
-				flashLED();
-			memReadPos += reader.lastReadResult.bytesRead;
-			continue;
-		}
+				// Create folder if it doesn't exist yet
+				FRESULT mkdirResult = f_mkdir_secondary_drive("/Slippi");
+				if (mkdirResult != FR_OK && mkdirResult != FR_EXIST)
+				{
+					dbgprintf("Slippi: failed to mkdir: /Slippi, errno: %d\r\n", mkdirResult);
+					break;
+				}
 
-		UINT wrote;
-		FRESULT writeResult = f_write(&currentFile, readBuf, reader.lastReadResult.bytesRead, &wrote);
-		if (wrote == 0)
-			continue;
+				dbgprintf("Creating File...\r\n");
+				gameStartTime = GetCurrentTime();
+				char *fileName = generateFileName();
+				// Maybe can remove FA_READ since network thread doesn't share &currentFile
+				FRESULT fileOpenResult = f_open_secondary_drive(&currentFile, fileName, FA_CREATE_ALWAYS | FA_WRITE | FA_READ);
+				if (fileOpenResult != FR_OK)
+				{
+					dbgprintf("Slippi: failed to open file: %s, errno: %d\r\n", fileName, fileOpenResult);
+					break;
+				}
 
-		// Only increment mem read position when some data is correctly written
-		memReadPos += wrote;
-		writtenByteCount += wrote;
+				currentFileOpen = true;
+				writtenByteCount = 0;
+				
+				FRESULT writeHeaderResult = writeHeader(&currentFile);
+				if (writeHeaderResult != FR_OK)
+					break;
 
-		if (reader.lastReadResult.isGameEnd && writeResult == FR_OK)
-		{
-			dbgprintf("Completing File...\r\n");
-			FRESULT completeResult = completeFile(&currentFile, &reader, writtenByteCount);
-			FRESULT closeResult = f_close(&currentFile);
-			hasFile = false;
-			if (replaysLED && writeResult == FR_OK && completeResult == FR_OK && closeResult == FR_OK)
-				flashLED();
-		} else {
-			FRESULT syncResult = f_sync(&currentFile);
-			if (replaysLED && writeResult == FR_OK && syncResult == FR_OK)
-				flashLED();
+				currentFileValid = true;
+			}
+
+			if (!currentFileValid)
+			{
+				// we can reach this state if we SlippiRestoreReadPos into 
+				// the middle of a game due to usb insertion or SlpMemError
+				// skip over and don't write anything until we see the start of a new game
+				if (replaysLED)
+					flashLED();
+				memReadPos += reader.lastReadResult.bytesRead;
+				break;
+			}
+
+			// Always seek first in case there was a previous failure with partial write
+			FRESULT seekResult = f_lseek(&currentFile, writtenByteCount + 15);
+			if (seekResult != FR_OK)
+				break;
+
+			UINT wrote;
+			FRESULT writeResult = f_write(&currentFile, readBuf, reader.lastReadResult.bytesRead, &wrote);
+			if (writeResult == FR_OK)
+			{
+				// Only increment mem read position when the write fully succeeds
+				memReadPos += wrote;
+				writtenByteCount += wrote;
+
+				if (reader.lastReadResult.isGameEnd)
+				{
+					dbgprintf("Completing File...\r\n");
+					lastFrame = reader.metadata.lastFrame;
+					FRESULT completeResult = completeFile(&currentFile, lastFrame, writtenByteCount);
+					if (completeResult != FR_OK)
+						break;
+
+					currentFileValid = false;
+					FRESULT closeResult = f_close(&currentFile);
+					if (closeResult == FR_OK)
+					{
+						currentFileOpen = false;
+						if (replaysLED)
+							flashLED();
+					}
+
+					break;
+				}
+				else if (replaysLED)
+					flashLED();
+			}
+			else
+			{
+				break;
+			}
 		}
 	}
 

--- a/kernel/SlippiFileWriter.c
+++ b/kernel/SlippiFileWriter.c
@@ -182,19 +182,32 @@ FRESULT completeFile(FIL *file, s32 lastFrame, u32 writtenByteCount)
 	// Always seek first in case there was a previous failure with partial write
 	FRESULT fRes = f_lseek(file, writtenByteCount + 15);
 	if (fRes != FR_OK)
+	{
+		dbgprintf("Slippi: failed to seek before writing footer, errno: %d\r\n", fRes);
 		return fRes;
+	}
 
 	u32 wrote;
 	fRes = f_write(file, footer, writePos, &wrote);
 	if (fRes != FR_OK)
+	{
+		dbgprintf("Slippi: failed to write footer, errno: %d\r\n", fRes);
 		return fRes;
+	}
 
 	// Write length
 	fRes = f_lseek(file, 11);
 	if (fRes != FR_OK)
+	{
+		dbgprintf("Slippi: failed to seek before writing length, errno: %d\r\n", fRes);
 		return fRes;
+	}
 
-	return f_write(file, &writtenByteCount, 4, &wrote);
+	fRes = f_write(file, &writtenByteCount, 4, &wrote);
+	if (fRes != FR_OK)
+		dbgprintf("Slippi: failed to write length, errno: %d\r\n", fRes);
+	
+	return fRes;
 }
 
 static u32 SlippiHandlerThread(void *arg)
@@ -239,18 +252,21 @@ static u32 SlippiHandlerThread(void *arg)
 			}
 			else if (!mounted && !failedToMount)
 			{
-				if (f_mount_char(devices[1], "usb:", 1) == FR_OK)
+				FRESULT mountResult = f_mount_char(devices[1], "usb:", 1);
+				if (mountResult != FR_OK)
+				{
+					dbgprintf("Slippi: failed to mount usb, errno: %d\r\n", mountResult);
+
+					// only attempt to mount once, user can retry by re-inserting the device.
+					failedToMount = true;
+				}
+				else
 				{
 					// ignore anything already in the buffer. users should not expect to record a
 					// game if the usb device is inserted after game start.
 					memReadPos = SlippiRestoreReadPos();
 
 					mounted = true;
-				}
-				else
-				{
-					// only attempt to mount once, user can retry by re-inserting the device.
-					failedToMount = true;
 				}
 			}
 			if (!mounted)
@@ -269,8 +285,14 @@ static u32 SlippiHandlerThread(void *arg)
 				if (currentFileOpen)
 				{
 					FRESULT closeResult = f_close(&currentFile);
-					if (closeResult == FR_OK)
+					if (closeResult != FR_OK)
+					{
+						dbgprintf("Slippi: failed to close incompletable file, errno: %d\r\n", closeResult);
+					}
+					else
+					{
 						currentFileOpen = false;
+					}
 				}
 				break;
 			}
@@ -329,7 +351,10 @@ static u32 SlippiHandlerThread(void *arg)
 				
 				FRESULT writeHeaderResult = writeHeader(&currentFile);
 				if (writeHeaderResult != FR_OK)
+				{
+					dbgprintf("Slippi: failed to write header, errno: %d\r\n", writeHeaderResult);
 					break;
+				}
 
 				currentFileValid = true;
 			}
@@ -348,11 +373,19 @@ static u32 SlippiHandlerThread(void *arg)
 			// Always seek first in case there was a previous failure with partial write
 			FRESULT seekResult = f_lseek(&currentFile, writtenByteCount + 15);
 			if (seekResult != FR_OK)
+			{
+				dbgprintf("Slippi: failed to seek before writing data, errno: %d\r\n", seekResult);
 				break;
+			}
 
 			UINT wrote;
 			FRESULT writeResult = f_write(&currentFile, readBuf, reader.lastReadResult.bytesRead, &wrote);
-			if (writeResult == FR_OK)
+			if (writeResult != FR_OK)
+			{
+				dbgprintf("Slippi: failed to write data, errno: %d\r\n", writeResult);
+				break;
+			}
+			else
 			{
 				// Only increment mem read position when the write fully succeeds
 				memReadPos += wrote;
@@ -364,11 +397,18 @@ static u32 SlippiHandlerThread(void *arg)
 					lastFrame = reader.metadata.lastFrame;
 					FRESULT completeResult = completeFile(&currentFile, lastFrame, writtenByteCount);
 					if (completeResult != FR_OK)
+					{
+						// error is logged in completeFile
 						break;
+					}
 
 					currentFileValid = false;
 					FRESULT closeResult = f_close(&currentFile);
-					if (closeResult == FR_OK)
+					if (closeResult != FR_OK)
+					{
+						dbgprintf("Slippi: failed to close completed file, errno: %d\r\n", closeResult);
+					}
+					else
 					{
 						currentFileOpen = false;
 						if (replaysLED)
@@ -379,10 +419,6 @@ static u32 SlippiHandlerThread(void *arg)
 				}
 				else if (replaysLED)
 					flashLED();
-			}
-			else
-			{
-				break;
 			}
 		}
 	}

--- a/kernel/SlippiMemory.c
+++ b/kernel/SlippiMemory.c
@@ -94,6 +94,7 @@ void SlippiMemoryWrite(const u8 *buf, u32 len)
 SlpMemError SlippiMemoryRead(SlpGameReader *reader, u8 *buf, u32 bufLen, u64 readPos)
 {
 	// Reset previous read result
+	reader->lastReadResult.bytesAvailable = 0;
 	reader->lastReadResult.bytesRead = 0;
 	reader->lastReadResult.isGameEnd = false;
 	reader->lastReadResult.isNewGame = false;
@@ -176,6 +177,7 @@ SlpMemError SlippiMemoryRead(SlpGameReader *reader, u8 *buf, u32 bufLen, u64 rea
 	// Save the read cursor and number of bytes we've read
 	reader->lastReadPos = readPos;
 	reader->lastReadResult.bytesRead = bytesRead;
+	reader->lastReadResult.bytesAvailable = posDiff;
 
 	return errCode;
 }

--- a/kernel/SlippiMemory.h
+++ b/kernel/SlippiMemory.h
@@ -28,6 +28,7 @@ typedef struct SlpMetadata
 
 typedef struct SlpReadResult
 {
+	u64 bytesAvailable;
 	bool isNewGame;
 	bool isGameEnd;
 	u32 bytesRead;


### PR DESCRIPTION
this has been tested by myself personally on a weekly basis for 9 months and at locals around the world as well

- add more explicit error handling which should allow us to recover in some cases
- remove `f_sync` calls as incomplete files are not actually particularly useful
- always write as close to 4096 bytes as possible, which is a common physical sector size